### PR TITLE
Add find-flights tool with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# tools
+# Edge Talk Tools
+
+A collection of tools and utilities for Edge Talk.
+
+## Available Tools
+
+### Basic Calculator
+- [Find Flights Tool](basic-calculator/README.md) - A tool to find flights between airports using Aviation Stack API

--- a/basic-calculator/README.md
+++ b/basic-calculator/README.md
@@ -1,0 +1,55 @@
+# Find Flights Tool
+
+This tool demonstrates the power and simplicity of writing tools in Shards. It provides functionality to find flights between two airports using the Aviation Stack API.
+
+## Tool Description
+
+The find-flights tool is a simple yet powerful example that:
+- Takes departure and arrival airports in IATA format
+- Queries the Aviation Stack API for flight information
+- Filters flights for the current date
+- Returns a formatted list of flights with relevant information
+
+## How It Works
+
+The tool is written in Shards, showcasing several key features:
+
+1. **Wire Definition**: The main functionality is encapsulated in a wire called `find-flights`
+2. **Parameter Handling**: Uses Shards' built-in parameter validation and type checking
+3. **API Integration**: Demonstrates HTTP requests and JSON handling
+4. **Data Processing**: Shows how to filter and transform data efficiently
+
+## Code Structure
+
+```shards
+@wire(find-flights {
+  {Take("from") | ExpectString = from}
+  {Take("to") | ExpectString = to}
+  ...
+})
+```
+
+The tool definition is clean and self-documenting, showing how easy it is to:
+- Define input parameters
+- Handle API calls
+- Process and transform data
+- Return formatted results
+
+## Why Shards is Great for Tools
+
+1. **Declarative Syntax**: Shards' wire-based approach makes it natural to express data flow
+2. **Built-in Type Safety**: Strong type checking with `ExpectString`, `ExpectTable`, etc.
+3. **Composability**: Easy to combine operations with the pipe operator `|`
+4. **API Integration**: Simple HTTP requests and JSON handling
+5. **Error Handling**: Built-in error propagation and validation
+
+## Usage
+
+```shards
+{
+  from: "KIX"
+  to: "SIN"
+} | find-flights
+```
+
+This tool requires an Aviation Stack API key set in the environment as `aviationstack-api-key`.

--- a/basic-calculator/find-flights.shs
+++ b/basic-calculator/find-flights.shs
@@ -1,0 +1,62 @@
+@wire(find-flights {
+  ; input will be a table, so we take the columns we need
+  ; in this case, we need the columns we need
+  {Take("from") | ExpectString = from}
+  {Take("to") | ExpectString = to}
+  
+  Time.Epoch | Date.Format("%Y-%m-%d") = date
+  env:aviationstack-api-key | ExpectString = api-key
+  
+  ["https://api.aviationstack.com/v1/flights?access_key=" api-key "&dep_iata=" from "&arr_iata=" to] | String.Join = url
+  none | Http.Get(url Timeout: 30) | Log("flight-info") | Await(FromJson) | ExpectTable = flight-info
+  flight-info:data | ExpectSeq >= flights
+  
+  ; remove flights that are not on today's date
+  Remove(From: flights Predicate: {
+    ExpectTable | Take("flight_date") | ExpectString | IsNot(date)
+  })
+  
+  ; compress the table a bit, remove the columns we don't need
+  flights | Map({
+    ExpectTable
+    {
+      airline: (Take("airline"))
+      flight: (Take("flight"))
+      departure: (Take("departure"))
+      arrival: (Take("arrival"))
+    }
+  }) | ToString
+})
+
+{
+  definition: {
+    name: "find_flights"
+    description: "Find flights between two airports."
+    parameters: {
+      type: "object"
+      properties: {
+        from: {
+          type: "string"
+          description: "The departure airport in IATA format. e.g. KIX, no spaces."
+        }
+        to: {
+          type: "string"
+          description: "The arrival airport in IATA format. e.g. SIN, no spaces."
+        }
+      }
+      required: ["from" "to"]
+    }
+  }
+  
+  use: find-flights
+}
+
+; ; Test code
+; Log = tool
+
+; tool:use | ExpectWire = find-flights-wire
+
+; {
+;   from: "KIX"
+;   to: "SIN"
+; } | WireRunner(find-flights-wire) | Log


### PR DESCRIPTION
This PR adds:

1. Find Flights tool in the basic-calculator folder
2. Detailed README.md explaining the tool and Shards capabilities
3. Updated root README.md with tools index

The find-flights tool demonstrates:
- Simple yet powerful Shards syntax
- API integration capabilities
- Data processing and transformation
- Strong typing and error handling

The tool requires an Aviation Stack API key to function.