### PR TITLE
fix: Move flight tool to appropriate flight-search folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# tools
+# Edge Talk Tools
+
+A collection of tools and utilities for Edge Talk.
+
+## Available Tools
+
+### Flight Search
+- [Flight Search Tool](flight-search/README.md) - Real-time flight information search between airports using Aviation Stack API

--- a/flight-search/README.md
+++ b/flight-search/README.md
@@ -1,0 +1,53 @@
+# Flight Search Tool
+
+A Shards-based tool for searching real-time flight information between airports using the Aviation Stack API.
+
+## Tool Description
+
+The flight-search tool provides a simple interface to:
+- Query flights between two airports using IATA codes
+- Get real-time flight information for the current date
+- Return formatted flight details including airline, flight number, and timing information
+
+## How It Works
+
+The tool leverages Shards' powerful wire system to:
+1. Take departure and arrival airport codes as input
+2. Query the Aviation Stack API
+3. Filter flights for the current date
+4. Return relevant flight information in a clean format
+
+## Code Structure
+
+```shards
+@wire(find-flights {
+  {Take("from") | ExpectString = from}
+  {Take("to") | ExpectString = to}
+  ...
+})
+```
+
+The implementation showcases Shards' elegant syntax for:
+- Parameter handling and validation
+- HTTP requests and JSON processing
+- Data filtering and transformation
+- Clean error handling
+
+## Why Shards Excels for API Tools
+
+1. **Declarative Flow**: Shards' wire-based approach makes data flow clear and maintainable
+2. **Built-in Type Safety**: Strong type checking prevents runtime errors
+3. **Composable Operations**: The pipe operator `|` enables clean function composition
+4. **HTTP Integration**: Simple, powerful HTTP request handling
+5. **JSON Processing**: Native JSON support with type-safe parsing
+
+## Usage Example
+
+```shards
+{
+  from: "KIX"
+  to: "SIN"
+} | find-flights
+```
+
+Note: Requires an Aviation Stack API key set in the environment as `aviationstack-api-key`.

--- a/flight-search/find-flights.shs
+++ b/flight-search/find-flights.shs
@@ -1,0 +1,62 @@
+@wire(find-flights {
+  ; input will be a table, so we take the columns we need
+  ; in this case, we need the columns we need
+  {Take("from") | ExpectString = from}
+  {Take("to") | ExpectString = to}
+  
+  Time.Epoch | Date.Format("%Y-%m-%d") = date
+  env:aviationstack-api-key | ExpectString = api-key
+  
+  ["https://api.aviationstack.com/v1/flights?access_key=" api-key "&dep_iata=" from "&arr_iata=" to] | String.Join = url
+  none | Http.Get(url Timeout: 30) | Log("flight-info") | Await(FromJson) | ExpectTable = flight-info
+  flight-info:data | ExpectSeq >= flights
+  
+  ; remove flights that are not on today's date
+  Remove(From: flights Predicate: {
+    ExpectTable | Take("flight_date") | ExpectString | IsNot(date)
+  })
+  
+  ; compress the table a bit, remove the columns we don't need
+  flights | Map({
+    ExpectTable
+    {
+      airline: (Take("airline"))
+      flight: (Take("flight"))
+      departure: (Take("departure"))
+      arrival: (Take("arrival"))
+    }
+  }) | ToString
+})
+
+{
+  definition: {
+    name: "find_flights"
+    description: "Find flights between two airports."
+    parameters: {
+      type: "object"
+      properties: {
+        from: {
+          type: "string"
+          description: "The departure airport in IATA format. e.g. KIX, no spaces."
+        }
+        to: {
+          type: "string"
+          description: "The arrival airport in IATA format. e.g. SIN, no spaces."
+        }
+      }
+      required: ["from" "to"]
+    }
+  }
+  
+  use: find-flights
+}
+
+; ; Test code
+; Log = tool
+
+; tool:use | ExpectWire = find-flights-wire
+
+; {
+;   from: "KIX"
+;   to: "SIN"
+; } | WireRunner(find-flights-wire) | Log


### PR DESCRIPTION
This PR fixes the folder structure for the flight search tool:

1. Moved the tool from incorrectly named `basic-calculator` to more appropriate `flight-search` folder
2. Updated README.md with proper folder references
3. Maintained all functionality of the find-flights tool

The tool provides:
- Real-time flight searches between airports
- Clean Shards implementation showcasing the language's power
- Proper organization in a dedicated flight-search folder

Note: This PR supersedes #1 with the correct folder structure.