### PR TITLE
Add flight-info tool with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,8 @@ A collection of tools and utilities for Edge Talk.
 
 ## Available Tools
 
+### Flight Information
+- [Flight Information Tool](flight-info/README.md) - Real-time flight status and details using flight numbers via Aviation Stack API
+
 ### Flight Search
 - [Flight Search Tool](find-flights/README.md) - Real-time flight information search between airports using Aviation Stack API

--- a/flight-info/README.md
+++ b/flight-info/README.md
@@ -1,0 +1,20 @@
+# Flight Information Tool
+
+A tool for retrieving detailed flight information using a flight number through the Aviation Stack API.
+
+## Tool Description
+
+The flight-info tool provides a simple interface to:
+- Query flight details using IATA flight numbers (e.g. SQ123)
+- Get real-time flight status and information
+- Return formatted flight details including timing, status, and route information
+
+## How It Works
+
+The tool uses the Aviation Stack API to:
+1. Take a flight number as input in IATA format
+2. Query the Aviation Stack API for flight details
+3. Return comprehensive flight information for up to 5 matching flights
+4. Format and display the results in a clean format
+
+Note: Requires an Aviation Stack API key set in the environment as `aviationstack-api-key`

--- a/flight-info/flight-info.shs
+++ b/flight-info/flight-info.shs
@@ -1,0 +1,39 @@
+@wire(flight-info {
+  ; input will be a table, so we take the columns we need
+  ; in this case, we need the columns we need
+  {Take("flight-number") | ExpectString = flight-number}
+
+  env:aviationstack-api-key | ExpectString = api-key
+  
+  ["https://api.aviationstack.com/v1/flights?access_key=" api-key "&flight_iata=" flight-number] | String.Join = url
+  none | Http.Get(url Timeout: 30) | Log("flight-info") | Await(FromJson) | ExpectTable = flight-info
+  flight-info:data | ExpectSeq | Limit(5) | ToString
+})
+
+{
+  definition: {
+    name: "flight_info"
+    description: "Get flight information for a given flight number."
+    parameters: {
+      type: "object"
+      properties: {
+        flight-number: {
+          type: "string"
+          description: "The flight number to get information for in IATA format. e.g. SQ123, no spaces."
+        }
+      }
+      required: ["flight-number"]
+    }
+  }
+  
+  use: flight-info
+}
+
+; ; Test code
+; Log = tool
+
+; tool:use | ExpectWire = flight-info-wire
+
+; {
+;   flight-number: "SQ623"
+; } | WireRunner(flight-info-wire) | Log


### PR DESCRIPTION
This PR adds:

1. New flight-info tool that allows querying flight information using IATA flight numbers
2. Documentation for the flight-info tool
3. Updated main README.md with link to the new tool

The tool uses the Aviation Stack API to retrieve real-time flight information and status.